### PR TITLE
Cache slot rework

### DIFF
--- a/PBQA/db.py
+++ b/PBQA/db.py
@@ -238,7 +238,9 @@ class DB:
         """
 
         if collection_name not in self.get_collections():
-            raise ValueError(f"Collection {collection_name} not found")
+            raise ValueError(
+                f"Collection {collection_name} not found. Make sure to load the pattern first or create the collection manually."
+            )
 
         metadata = self.client.scroll(
             collection_name="metadata",

--- a/PBQA/llm.py
+++ b/PBQA/llm.py
@@ -21,7 +21,6 @@ class LLM:
         self,
         db: DB,
         host: str = None,
-        cache_slots: int = 1,
     ):
         """
         Initialize the LLM (Language Learning Model.
@@ -31,14 +30,12 @@ class LLM:
         Parameters:
         - db (DB): The database to use for storing and retrieving examples.
         - host (str): The host of the LLM server. Can also be passed when connecting model servers.
-        - cache_slots (int): The number of cache slots to use for the LLM.
         """
 
         self.db = db
         self.host = host
 
-        self.cache_slots = cache_slots
-        self.cache_ids = {}
+        self.cache_slots = {}
 
         self.models = {}
 
@@ -51,7 +48,7 @@ class LLM:
         min_p: float = 0.07,
         top_p: float = 1.0,
         max_tokens: int = 4096,
-        stop: List[str] = None,
+        stop: List[str] = [],
         **kwargs,
     ) -> dict[str, str]:
         """
@@ -77,12 +74,9 @@ class LLM:
         if not host:
             raise ValueError("Failed to connect to LLM server. No host provided.")
 
-        if self.poke_server(host, port):
+        props = self.get_props(host, port)
+        if props != {}:
             log.info(f"Connected to model {model} at {host}:{port}")
-        else:
-            raise ValueError(
-                f"Failed to connect to LLM server at {host}:{port}. Ensure the server is running and the host and port are correct."
-            )
 
         self.models[model] = {
             "host": host,
@@ -91,7 +85,8 @@ class LLM:
             "min_p": min_p,
             "top_p": top_p,
             "max_tokens": max_tokens,
-            "stop": stop if stop else [],
+            "stop": stop,
+            "total_slots": props.get("total_slots", 1096),
             **kwargs,
         }
 
@@ -106,9 +101,21 @@ class LLM:
             return True
         except requests.exceptions.RequestException as e:
             log.warn(
-                f"Failed to connect to LLM server at {host}:{port}. Ensure the server is running."
+                f"Failed to connect to LLM server at {host}:{port}. Ensure the server is running and the host and port are correct."
             )
             return False
+
+    @staticmethod
+    def get_props(host: str, port: int) -> dict:
+        url = f"http://{host}:{port}"
+
+        try:
+            response = requests.get(url + "/props")
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise ValueError(
+                f"Failed to get properties from LLM server at {host}:{port}. Ensure the server is running and the host and port are correct."
+            )
 
     def _get_response(
         self,
@@ -126,7 +133,7 @@ class LLM:
         n_example: int = 0,
         min_d: float = None,
         use_cache: bool = True,
-        cache_id: int = None,
+        cache_slot: int = None,
         grammar: str = None,
         stop: List[str] = [],
         **kwargs,
@@ -149,7 +156,7 @@ class LLM:
         - n_example (int): The number of examples to load from the database.
         - min_d (float): The minimum distance between the input and the examples.
         - use_cache (bool): Whether to use the cache for the response.
-        - cache_id (int): The cache ID to use for the response.
+        - cache_slot (int): The cache slot to use for the response.
         - grammar (str): The grammar to use for the response.
         - stop (List[str]): Strings to stop the response generation.
         - kwargs: Additional arguments to pass when querying the database.
@@ -167,8 +174,15 @@ class LLM:
             e for e in exclude if e not in metadata["components"]
         ]:
             raise ValueError(
-                f"components {not_present_components} to exclude not found in pattern {pattern}"
+                f"Components {not_present_components} to exclude not found in pattern {pattern}"
             )
+
+        if not cache_slot or cache_slot >= self.models[model].get("total_slots", 1096):
+            if cache_slot:
+                log.warn(
+                    f"Provided cache slot {cache_slot} exceeds the maximum number of cache slots {self.models[model].get('total_slots', 1096)} or pattern {pattern} and model {model}. Using the last slot instead."
+                )
+            cache_slot = self._get_cache_slot(pattern, model)
 
         messages = self._format_messages(
             input=input,
@@ -191,37 +205,32 @@ class LLM:
             exclude=exclude,
         )
 
-        model_defaults = self.models[model]
-
-        parameters = {
-            **model_defaults,
-            **kwargs,  # This will override the defaults if any of these keys are present in kwargs
-        }
-        parameters["stop"] = model_defaults["stop"] + stop
-
-        log.info(f"Request:\n{yaml.dump(parameters, default_flow_style=False)}")
+        parameters = {**self.models[model], **kwargs}
+        parameters["stop"] = parameters.get("stop", []) + stop
 
         data = {
             "model": model,
-            "id_slot": cache_id
-            or self._get_cache_id(
-                pattern,
-                model,
-            ),
+            "id_slot": cache_slot,
             "cache_prompt": use_cache,
             "messages": messages,
             "grammar": grammar,
             **parameters,
         }
 
-        url = f"http://{parameters['host']}:{parameters['port']}/v1/chat/completions"
-        headers = {"Content-Type": "application/json", "Authorization": "Bearer no-key"}
+        # log.warn(f"grammar: {data['grammar']}")
 
         try:
+            url = (
+                f"http://{parameters['host']}:{parameters['port']}/v1/chat/completions"
+            )
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer no-key",
+            }
             llm_response = requests.post(url, headers=headers, data=dumps(data))
         except requests.exceptions.RequestException as e:
             raise ValueError(
-                f"Request to LLM failed: {str(e)}\n\nEnsure the llama.cpp server is running (python3 server/run.py)."
+                f"Request to LLM failed: {str(e)}\n\nEnsure the llama.cpp server is running."
             )
 
         llm_response = llm_response.json()
@@ -463,14 +472,15 @@ class LLM:
         grammars = {}
 
         for comp in metadata["components"]:
-            if (
-                comp in exclude
-                or not metadata[comp]
-                or metadata[comp].get("external", False)
+            if comp in exclude or (
+                metadata[comp] and metadata[comp].get("external", False)
             ):
                 continue
 
-            grammars[comp] = metadata[comp].get("grammar", None)
+            try:
+                grammars[comp] = metadata[comp]["grammar"]
+            except TypeError:
+                grammars[comp] = None
 
         if len(grammars) == 0:
             return None
@@ -504,16 +514,53 @@ string ::=
 
         return grammar
 
-    def _get_cache_id(self, pattern: str, model: str) -> str:
-        moniker = self.get_cache_name(pattern, model)
+    def assign_cache_slot(
+        self,
+        pattern: str,
+        model: str,
+        cache_slot: int = None,
+    ) -> int:
+        """
+        Assign a cache slot to a specific pattern-model pair.
 
-        if moniker not in self.cache_ids:
+        Parameters:
+        - pattern (str): The pattern to assign the cache slot to.
+        - model (str): The model to assign the cache slot to.
+        - cache_slot (int): The cache slot to assign to the pattern and model
+
+        Returns:
+        - int: The cache slot.
+        """
+        if not cache_slot:
+            return self._get_cache_slot(pattern, model)
+
+        moniker = self._get_cache_moniker(pattern, model)
+
+        self.cache_slots[moniker] = min(
+            cache_slot,
+            self.models[model].get("total_slots", 1096) - 1,
+        )
+
+        if cache_slot > self.models[model].get("total_slots", 1096) - 1:
+            log.warn(
+                f"Provided cache slot {cache_slot} is greater than the total number of cache slots {self.models[model].get('total_slots', 1096)} for pattern {pattern} and model {model}. Using the last slot instead."
+            )
+
+        return self.cache_slots[moniker]
+
+    def _get_cache_slot(self, pattern: str, model: str) -> str:
+        moniker = self._get_cache_moniker(pattern, model)
+
+        if moniker not in self.cache_slots:
             # Fill the cache slots in order. If all slots are filled, reuse the last slot
-            self.cache_ids[moniker] = min(len(self.cache_ids), self.cache_slots - 1)
+            self.cache_slots[moniker] = min(
+                len(self.cache_slots),
+                self.models[model].get("total_slots", 1096) - 1,
+            )
 
-        return self.cache_ids[moniker]
+        return self.cache_slots[moniker]
 
-    def get_cache_name(self, pattern: str, model: str) -> str:
+    def _get_cache_moniker(self, pattern: str, model: str) -> str:
         return f"{pattern}_{model}"
 
     def ask(
@@ -533,7 +580,7 @@ string ::=
         n_example: int = 0,
         min_d: float = None,
         use_cache: bool = True,
-        cache_id: int = None,
+        cache_slot: int = None,
         grammar: str = None,
         stop: List[str] = [],
         **kwargs,
@@ -557,7 +604,7 @@ string ::=
         - n_example (int): The number of examples to load from the database.
         - min_d (float): The minimum distance between the input and the examples.
         - use_cache (bool): Whether to use the cache for the response.
-        - cache_id (int): The ID of the cache/process slot to use for the response.
+        - cache_slot (int): The ID of the cache/process slot to use for the response.
         - grammar (str): The grammar to use for the response.
         - stop (List[str]): Strings to stop the response generation.
         - kwargs: Additional arguments to pass when querying the database.
@@ -595,7 +642,7 @@ string ::=
             n_example=n_example,
             min_d=min_d,
             use_cache=use_cache,
-            cache_id=cache_id,
+            cache_slot=cache_slot,
             grammar=grammar,
             stop=stop,
             **kwargs,

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ For more examples, look at the pattern files in the [examples](examples/README.m
 ### Cache
 Unless overridden, queries using the same pattern will use the same system prompt and base examples. This allows a large part of the response to be cached, speeding up generation. This can be disabled by setting `use_cache=False` in the `ask()` method.
 
-_Note:_ To cache the patterns, PBQA will try allocate a slot/process for each pattern-model pair in the llama.cpp server. As such, make sure to set `-np` to the amount of unique combinations of patterns and models you want to enable caching for.
+To cache the patterns, PBQA will try allocate a slot/process for each pattern-model pair in the llama.cpp server. As such, make sure to set `-np` to the amount of unique combinations of patterns and models you want to enable caching for. Then when initializing the `LLM()`, set `cache_slots` to the same amount.
+
+The slots are allocated in the order they are requested, filling up the first process before moving on to the next. If the number of slots is exceeded, the last slot is overwritten. Alternatively, set `cache_id` in the `ask()` method to manually pick a slot.
 
 ## Roadmap
 Future features in no particular order with no particular timeline:

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ examples:  # Lastly, examples can be provided for multi-shot prompting
 For more examples, look at the pattern files in the [examples](examples/README.md#patterns) directory. Information on the GBNF grammar format can be found [here](https://github.com/ggerganov/llama.cpp/tree/master/grammars#gbnf-guide).
 
 ### Cache
-Unless overridden, queries using the same pattern will use the same system prompt and base examples. This allows a large part of the response to be cached, speeding up generation. This can be disabled by setting `use_cache=False` in the `ask()` method.
+Unless overridden, queries using the same pattern will use the same system prompt and base examples, allowing a large part of the response to be cached and speeding up generation. This can be disabled by setting `use_cache=False` in the `ask()` method.
 
-To cache the patterns, PBQA will try allocate a slot/process for each pattern-model pair in the llama.cpp server. As such, make sure to set `-np` to the amount of unique combinations of patterns and models you want to enable caching for. Then when initializing the `LLM()`, set `cache_slots` to the same amount.
+PBQA allocates a slot/process for each pattern-model pair in the llama.cpp server. Set `-np` to the number of unique combinations of patterns and models you want to enable caching for. Slots are allocated in the order they are requested, and if the number of available slots is exceeded, the last slot is reused for any excess pattern-model pairs.
 
-The slots are allocated in the order they are requested, filling up the first process before moving on to the next. If the number of slots is exceeded, the last slot is overwritten. Alternatively, set `cache_id` in the `ask()` method to manually pick a slot.
+You can manually assign a cache slot to a specific pattern-model pair using the `assign_cache_slot` method. Optionally, a specific cache slot can be provided, up to the number of available processes. The cache slot used for a query can also be overridden by passing the `cache_slot` parameter to the `llm.ask()` method.
 
 ## Roadmap
 Future features in no particular order with no particular timeline:

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,13 @@ Lastly, examples may be provided in the pattern file for [multi-shot prompting](
 
 See the [conversation section](#conversation) for an example of a pattern with a system prompt, or the [function calling section](#function-calling) for an example of patterns with grammars, examples, and external data.
 
+## Caching
+Unless overridden, queries using the same pattern will use the same system prompt and base examples. This allows a large part of the response to be cached, speeding up generation. This can be disabled by setting `use_cache=False` in the `ask()` method.
+
+To cache the patterns, PBQA will try allocate a slot/process for each pattern-model pair in the llama.cpp server. As such, make sure to set `-np` to the amount of unique combinations of patterns and models you want to enable caching for. Then when initializing the `LLM()`, set `cache_slots` to the same amount.
+
+The slots are allocated in the order they are requested, filling up the first process before moving on to the next. If the number of slots is exceeded, the last slot is overwritten. Alternatively, set `cache_id` in the `ask()` method to manually pick a slot.
+
 # Conversation
 Conversational agents are a common usecase for LLMs. While PBQA allows for [structured responses](#grammar), it can also be used to generate free-form responses. Below is an example of a pattern file for a conversational agent.
 

--- a/examples/feedback.py
+++ b/examples/feedback.py
@@ -34,6 +34,7 @@ db.add(
     feedback=True,
 )
 
+# See the repetition caveat in the README
 # db.add(
 #     input="Is it going to rain tonight at home?",
 #     collection_name="weather",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="PBQA",
-    version="0.1.9",
+    version="0.1.10",
     description="Pattern Based Question and Answer (PBQA) is a Python library that provides tools for querying LLMs and managing text embeddings. It combines guided generation with multi-shot prompting to improve response quality and consistency.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Unless overridden, queries using the same pattern will use the same system prompt and base examples. This allows a large part of the response to be cached, speeding up generation. This can be disabled by setting `use_cache=False` in the `ask()` method.

To cache the patterns, PBQA will try to allocate a slot/process for each pattern-model pair in the llama.cpp server. As such, make sure to set `-np` to the number of unique combinations of patterns and models you want to enable caching for. 

Unless manually assigned, the slots are allocated in the order they are requested. If the number of available slots is exceeded, the last slot is reused for any excess pattern-model pairs. This ensures that the cache slot will never exceed the number of processes available.

The `assign_cache_slot` method can be used to manually assign a cache slot to a specific pattern-model pair. This method assigns a cache slot to a given pattern and model combination. Optionally, a specific cache slot can be provided, up to the number of available processes.


```python
from PBQA import DB, LLM


db = DB(path="examples/db")
db.load_pattern("examples/weather.yaml")

llm = LLM(db=db, host="127.0.0.1")
llm.connect_model(
    model="llama",
    port=8080,
    stop=["<|eot_id|>", "<|start_header_id|>"],
    temperature=0,
)
llm.assign_cache_slot(pattern="weather", model="llama")
```

Note that, while usually the cache slot used for a query is the one assigned to the pattern-model pair, the cache slot can be overridden by passing the `cache_slot` parameter to the `llm.ask()` method.