### PR TITLE
Exclude input

### DIFF
--- a/PBQA/llm.py
+++ b/PBQA/llm.py
@@ -306,7 +306,7 @@ class LLM:
             external_keys_set = set(external.keys())
 
             components = [item for item in components if not include or item in include]
-            components.append("input")
+            components.insert(0, "input")
 
             user_components = [
                 item
@@ -330,13 +330,20 @@ class LLM:
                 response: dict,
                 components: List[str],
             ) -> dict[str, str]:
-                if len(components) == 1:
-                    return {"role": role, "content": response[components[0]]}
-                else:
-                    return {
-                        "role": role,
-                        "content": dumps({comp: response[comp] for comp in components}),
-                    }
+                try:
+                    if len(components) == 1:
+                        return {"role": role, "content": response[components[0]]}
+                    else:
+                        return {
+                            "role": role,
+                            "content": dumps(
+                                {comp: response[comp] for comp in components}
+                            ),
+                        }
+                except KeyError:
+                    raise KeyError(
+                        f"Failed to format role {role}. Missing component(s) {[comp for comp in components if comp not in response.keys()]}. Make sure to provide all components in the response and to save the response with the correct components."
+                    )
 
             formatted_responses = []
 

--- a/PBQA/llm.py
+++ b/PBQA/llm.py
@@ -306,7 +306,9 @@ class LLM:
             external_keys_set = set(external.keys())
 
             components = [item for item in components if not include or item in include]
-            components.insert(0, "input")
+            components.append(
+                "input"
+            )  # input is appended to the end of the list to ensure it is the last component in the message on the user side. This is helpful if a history is prepended externally.
 
             user_components = [
                 item

--- a/examples/conversation.py
+++ b/examples/conversation.py
@@ -1,4 +1,7 @@
 from PBQA import DB, LLM
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 
 db = DB(path="examples/db")
@@ -14,11 +17,18 @@ llm.connect_model(
 while True:
     user_input = input("User\n> ")
 
+    hist = db.where(collection_name="conversation", n=10)
+    hist.reverse()
+
+    hist = [{"input": item["input"], "reply": item["reply"]} for item in hist]
+
     response = llm.ask(
         input=user_input,
         pattern="conversation",
         model="llama",
+        external={"hist": hist},
         n_hist=50,
+        return_external=True,
     )
 
     db.add(

--- a/examples/conversation.py
+++ b/examples/conversation.py
@@ -17,18 +17,11 @@ llm.connect_model(
 while True:
     user_input = input("User\n> ")
 
-    hist = db.where(collection_name="conversation", n=10)
-    hist.reverse()
-
-    hist = [{"input": item["input"], "reply": item["reply"]} for item in hist]
-
     response = llm.ask(
         input=user_input,
         pattern="conversation",
         model="llama",
-        external={"hist": hist},
         n_hist=50,
-        return_external=True,
     )
 
     db.add(

--- a/examples/conversation.yaml
+++ b/examples/conversation.yaml
@@ -1,2 +1,4 @@
 system_prompt: You are a virtual assistant. You are here to help where you can or simply engage in conversation. Your tone is casual, on the side of serious, but warm overall. Don't feel the need to respond with an entire paragraph if a simple sentence will do.
+hist:
+  external: true
 reply:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="PBQA",
-    version="0.1.10",
+    version="0.1.11",
     description="Pattern Based Question and Answer (PBQA) is a Python library that provides tools for querying LLMs and managing text embeddings. It combines guided generation with multi-shot prompting to improve response quality and consistency.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
"input" can now be excluded from (the user's side of) the response. This way the user's side of the exchanges may be completely replaced by external data. For example, a list of previous messages may be passed as part of the user's side of an exchange, allowing for use of a history and examples in conjunction.