### PR TITLE
Model optional

### DIFF
--- a/PBQA/db.py
+++ b/PBQA/db.py
@@ -95,7 +95,7 @@ class DB:
 
         if collection_name not in self.get_collections():
             log.info(
-                f"Loading pattern {pattern_name} into collection {collection_name}"
+                f'Loading pattern {pattern_name} into collection "{collection_name}"'
             )
             self._add_from_file(path, collection_name=collection_name)
             self.index(collection_name, "time_added", "float")
@@ -122,7 +122,7 @@ class DB:
         """
         prev = time()
 
-        log.info(f"Populating collection {collection_name} with {path}")
+        log.info(f'Populating collection "{collection_name}" with {path}')
 
         data = self.load_from_file(path)
 
@@ -176,7 +176,7 @@ class DB:
         """
         if collection_name not in self.get_collections():
             log.info(
-                f"Creating collection {collection_name} with metadata:\n{yaml.dump(metadata, default_flow_style=False)}"
+                f'Creating collection "{collection_name}" with metadata:\n{yaml.dump(metadata, default_flow_style=False)}'
             )
 
             config = models.VectorParams(
@@ -207,11 +207,11 @@ class DB:
                 **kwargs,
             )
         else:
-            log.info(f"Collection {collection_name} already exists")
+            log.info(f'collection "{collection_name}" already exists')
 
     def delete_collection(self, collection_name: str):
         if collection_name not in self.get_collections():
-            raise ValueError(f"Collection {collection_name} not found")
+            raise ValueError(f'collection "{collection_name}" not found')
 
         self.client.delete_collection(collection_name=collection_name)
 
@@ -238,7 +238,7 @@ class DB:
         """
         if collection_name not in self.get_collections():
             raise ValueError(
-                f"Collection {collection_name} not found. Make sure to load the pattern first or create the collection manually."
+                f'collection "{collection_name}" not found. Make sure to load the pattern first or create the collection manually.'
             )
 
         time_added = time_added or time()
@@ -286,7 +286,7 @@ class DB:
             pattern in self.get_patterns() or collection_name in self.get_collections()
         ):
             raise ValueError(
-                f"Neither pattern {pattern} nor collection {collection_name} found. Make sure to load the pattern first or create the collection manually."
+                f'Neither pattern "{pattern}" nor collection "{collection_name}" found. Make sure to load the pattern first or create the collection manually.'
             )
 
         if pattern:
@@ -343,7 +343,7 @@ class DB:
     def n(self, collection_name: str):
         """Get the number of documents in a collection."""
         if collection_name not in self.get_collections():
-            raise ValueError(f"Collection {collection_name} not found")
+            raise ValueError(f'collection "{collection_name}" not found')
 
         try:
             return self.client.count(collection_name)
@@ -415,11 +415,11 @@ class DB:
         if pattern not in self.get_patterns():
             if pattern not in self.get_collections():
                 raise ValueError(
-                    f"Neither pattern {pattern} nor collection {collection_name} found. Make sure to load the pattern first or create the collection manually."
+                    f'Neither pattern "{pattern}" nor collection "{collection_name}" found. Make sure to load the pattern first or create the collection manually.'
                 )
             else:
                 log.warn(
-                    f"No collection associated with pattern {pattern}. Using collection name {pattern} for query instead."
+                    f'No collection associated with pattern "{pattern}". Using collection name "{pattern}" for query instead.'
                 )
                 collection_name = pattern
         else:
@@ -502,11 +502,11 @@ class DB:
         if pattern not in self.get_patterns():
             if pattern not in self.get_collections():
                 raise ValueError(
-                    f"Neither pattern {pattern} nor collection {collection_name} found. Make sure to load the pattern first or create the collection manually."
+                    f'Neither pattern "{pattern}" nor collection "{collection_name}" found. Make sure to load the pattern first or create the collection manually.'
                 )
             else:
                 log.warn(
-                    f"No collection associated with pattern {pattern}. Using collection name {pattern} for query instead."
+                    f'No collection associated with pattern "{pattern}". Using collection name "{pattern}" for query instead.'
                 )
                 collection_name = pattern
         else:
@@ -560,7 +560,7 @@ class DB:
             return
 
         if pattern not in self.get_collections():
-            raise ValueError(f"Pattern {pattern} not found")
+            raise ValueError(f'Pattern "{pattern}" not found')
         if type not in [
             "keyword",
             "integer",

--- a/PBQA/llm.py
+++ b/PBQA/llm.py
@@ -625,7 +625,7 @@ string ::=
         Parameters:
         - input (str): The input to the LLM.
         - pattern (str): The pattern to use for generating the response.
-        - model (str): The model to use for generating the response.
+        - model (str): The model to use for generating the response. If None, the model assigned during the last appropriate `link` call is used.
         - external (dict[str, str]): External data to include in the response.
         - return_external (bool): Whether to return the external data in the response.
         - history_name (str): The name of the history to use for generating the response.

--- a/PBQA/llm.py
+++ b/PBQA/llm.py
@@ -557,6 +557,16 @@ string ::=
         Returns:
         - int: The cache slot.
         """
+
+        if pattern not in self.db.get_patterns():
+            raise ValueError(
+                f'Pattern "{pattern}" not found. Make sure to load the pattern first using the `db.load_pattern()` method.'
+            )
+        if model not in self.models:
+            raise ValueError(
+                f'Model "{model}" not found. Make sure to connect the model first using the `llm.connect_model()` method.'
+            )
+
         moniker = self._get_cache_moniker(pattern, model)
         total_slots = self.models[model].get("total_slots", 1096)
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Unless overridden, queries using the same pattern will use the same system promp
 
 PBQA allocates a slot/process for each pattern-model pair in the llama.cpp server. Set `-np` to the number of unique combinations of patterns and models you want to enable caching for. Slots are allocated in the order they are requested, and if the number of available slots is exceeded, the last slot is reused for any excess pattern-model pairs.
 
-You can manually assign a cache slot to a specific pattern-model pair using the `assign_cache_slot` method. Optionally, a specific cache slot can be provided, up to the number of available processes. The cache slot used for a query can also be overridden by passing the `cache_slot` parameter to the `llm.ask()` method.
+You can manually assign a cache slot to a specific pattern-model pair using the `link` method. Optionally, a specific cache slot can be provided, up to the number of available processes. The cache slot used for a query can also be overridden by passing the `cache_slot` parameter to the `llm.ask()` method.
 
 ## Roadmap
 Future features in no particular order with no particular timeline:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ PBQA allocates a slot/process for each pattern-model pair in the llama.cpp serve
 
 You can manually assign a cache slot to a specific pattern-model pair using the `link` method. Optionally, a specific cache slot can be provided, up to the number of available processes. The cache slot used for a query can also be overridden by passing the `cache_slot` parameter to the `llm.ask()` method.
 
+```py
+from PBQA import DB, LLM
+
+
+db = DB(path="examples/db")
+db.load_pattern("examples/weather.yaml")
+
+llm = LLM(db=db, host="127.0.0.1")
+llm.connect_model(
+    model="llama",
+    port=8080,
+    stop=["<|eot_id|>", "<|start_header_id|>"],
+    temperature=0,
+)
+llm.link(pattern="weather", model="llama")
+```
+
+Once a pattern-model pair is linked, the "model" parameter in the `ask()` method may also be omitted. The query will instead use the model assigned during the last appropriate `link` call.
+
 ## Roadmap
 Future features in no particular order with no particular timeline:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ To cache the patterns, PBQA will try to allocate a slot/process for each pattern
 
 Unless manually assigned, the slots are allocated in the order they are requested. If the number of available slots is exceeded, the last slot is reused for any excess pattern-model pairs. This ensures that the cache slot will never exceed the number of processes available.
 
-The `assign_cache_slot` method can be used to manually assign a cache slot to a specific pattern-model pair. This method assigns a cache slot to a given pattern and model combination. Optionally, a specific cache slot can be provided, up to the number of available processes.
+The `link` method can be used to manually assign a cache slot to a specific pattern-model pair. This method assigns a cache slot to a given pattern and model combination. Optionally, a specific cache slot can be provided, up to the number of available processes.
 
 
 ```python
@@ -64,7 +64,7 @@ llm.connect_model(
     stop=["<|eot_id|>", "<|start_header_id|>"],
     temperature=0,
 )
-llm.assign_cache_slot(pattern="weather", model="llama")
+llm.link(pattern="weather", model="llama")
 ```
 
 Note that, while usually the cache slot used for a query is the one assigned to the pattern-model pair, the cache slot can be overridden by passing the `cache_slot` parameter to the `llm.ask()` method.


### PR DESCRIPTION
Specifying the model in an `llm.ask()` call is now optional, so long as the pattern used in the call was linked to a specific model using the `llm.link()` method (previously "assign_cache_slot").

Also changed the formatting in logs and errors to (hopefully) be more clear.