### PR TITLE
Valid json

### DIFF
--- a/PBQA/llm.py
+++ b/PBQA/llm.py
@@ -712,14 +712,15 @@ string ::=
         if len(expected_components) == 1:
             response = {metadata["components"][0]: content}
         else:
-            try:
-                response = json.loads(
-                    json.dumps(content)
-                )  # Ensure that the response is a valid JSON object
+            try:  # Ensure that the response is a valid JSON object
+                response = json.loads(content)
             except json.JSONDecodeError:
-                raise ValueError(
-                    f'Failed to parse response from LLM:\n\t{content}\n\nMake sure to that strings in the "{pattern}" pattern grammars are properly escaped with double quotes ("\\"...\\"") when returning multiple components.'
-                )
+                try:
+                    response = json.loads(json.dumps(content))
+                except json.JSONDecodeError:
+                    raise ValueError(
+                        f'Failed to parse response from LLM:\n\t{content}\n\nMake sure to that strings in the "{pattern}" pattern grammars are properly escaped with double quotes ("\\"...\\"") when returning multiple components.'
+                    )
 
         if return_external:
             response.update({comp: external[comp] for comp in external_components})

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="PBQA",
-    version="0.2.2",
+    version="0.2.3",
     description="Pattern Based Question and Answer (PBQA) is a Python library that provides tools for querying LLMs and managing text embeddings. It combines guided generation with multi-shot prompting to improve response quality and consistency.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixed json validation. Would previously break when generating markdown. Now that case would instead first fail, and then get `json.dump()`'ed, ensuring the string is valid before turning into an object.